### PR TITLE
Fix docker volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,7 @@ screepsplus-agent
 To use with docker, just do the following:
 ```
 docker build -t screepsplus-agent .
-docker run -d \
--v ./config.js:/config/config.js
---restart=always \
---name screepsplus-agent \
-screepsplus-agent
+docker run -d -v $(pwd):/config/ --restart=always --name screepsplus-agent screepsplus-agent
 ```
 
 ### Docker-compose

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To use with docker, just do the following:
 ```
 docker build -t screepsplus-agent .
 docker run -d \
+-v ./config.js:/config/config.js
 --restart=always \
 --name screepsplus-agent \
 screepsplus-agent


### PR DESCRIPTION
Added the "-v $(pwd):/config/" part to mount the config.js to the container.

It did not like the multi line flavour, so I've changed it so it's on a single line.

Using $(pwd) it should work from whatever folder the node-agent is checked out at. Because docker -v argument only accepts absolute paths.