### PR TITLE
Cleanup sample config file

### DIFF
--- a/config.js.sample
+++ b/config.js.sample
@@ -1,10 +1,12 @@
 // Please set the configuration below
 module.exports = {
+	sampleConfig: true // REMOVE THIS LINE BEFORE RUNNING
+
 	screeps: {
 		username: 'screepsUsernameHere',
 		password: 'screepsPasswordHere',
 		method: 'memory.stats', // Valid Options: 'console' 'memory.stats'
-//		segment: 99 // Uncomment this line and specify segment id if you're placing stats into segment
+//		segment: 99, // Uncomment this line and specify segment id if you're placing stats into segment
 		shard: 'shard0'
 	},
 	service: {
@@ -12,6 +14,5 @@ module.exports = {
 		token: 'apitoken'	// Token supplied upon account creation
 	},
 	checkForUpdates: true,
-	showRawStats: false, // This dumps stats to console on every push if enabled
-	sampleConfig: true // REMOVE THIS LINE BEFORE RUNNING
+	showRawStats: false // This dumps stats to console on every push if enabled
 }


### PR DESCRIPTION
Fix an issue with the segment line not having a comma.
Move the sampleConfig line to the top for better visibility and so the last line can have no comma.