### PR TITLE
support multiple shards

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ function start () {
   // console.log('Authenticated')
   console.log('Using stats method', config.screeps.method)
 
-  shards = [].concat(config.screeps.shard)
+  const shards = [].concat(config.screeps.shard)
 
   if (config.screeps.method === 'console') {
     beginConsoleStats()
@@ -114,7 +114,7 @@ function addLeaderboardData (stats) {
 
 function tick (shard) {
   Promise.resolve()
-    .then(() => console.log('Fetching Stats'))
+    .then(() => console.log('Fetching Stats (' + shard + ')'))
     .then(() => { return getStats(shard) })
     .then(processStats)
     .catch(err => console.error(err))
@@ -129,7 +129,6 @@ function processStats (data) {
 }
 
 function getStats (shard) {
-  console.log('getting stats (' + shard + ')')
   if (config.screeps.segment) {
     return api.memory.segment.get(config.screeps.segment, shard || 'shard0').then(r => r.data)
   } else {

--- a/config.js.sample
+++ b/config.js.sample
@@ -4,7 +4,7 @@ module.exports = {
 		token: 'Your Screeps Auth token. Goto your screeps account > Auth Token to get one.',
 		method: 'memory.stats', // Valid Options: 'console' 'memory.stats'
 //		segment: 99, // Uncomment this line and specify segment id if you're placing stats into segment
-		shard: 'shard0',
+		shard: ['shard0'], // An array of shards to pull data from.
 		connect: {
 			// For Private servers, uncomment the following:
 			// host: 'server1.screepspl.us',


### PR DESCRIPTION
Lets you set `shard` in config to an array of shards to pull data from.

If `shard` is a string it will be put into an array internally. 

The delay is set to `15000 * shards.length` to keep the delay within rate limits.